### PR TITLE
Added missing option to pass socket name to zmq sockets

### DIFF
--- a/src/SocketFactory.cpp
+++ b/src/SocketFactory.cpp
@@ -27,7 +27,7 @@ ISocket *SocketFactory::createClientSocket(Channel channel, Semantics semantics,
   }else if(channel.context == LOCAL_SHM){
     return m_shmFactory->createClientSocket(channel, semantics, deallocator);
   }else{
-    return m_zmqFactory->createClientSocket(channel, semantics, deallocator);
+    return m_zmqFactory->createClientSocket(channel, semantics, deallocator,name);
   }
 }
 


### PR DESCRIPTION
Hi Roberto,

I added ability to pass user defined socket names to zmq sockets. Default identifiers in ZMQ sockets can not be put in strings (0+32bit random) and is breaking yampl directed send requests. 

Cheers,
Sami
