### PR TITLE
Fixes for clang warnings

### DIFF
--- a/zeromq/src/i_msg_sink.hpp
+++ b/zeromq/src/i_msg_sink.hpp
@@ -29,13 +29,14 @@ namespace zmq
 
     //  Interface to be implemented by message sink.
 
-    struct i_msg_sink
+    class i_msg_sink
     {
-        virtual ~i_msg_sink () {}
+        public: 
+          virtual ~i_msg_sink () {}
 
-        //  Delivers a message. Returns 0 if successful; -1 otherwise.
-        //  The function takes ownership of the passed message.
-        virtual int push_msg (msg_t *msg_) = 0;
+          //  Delivers a message. Returns 0 if successful; -1 otherwise.
+          //  The function takes ownership of the passed message.
+          virtual int push_msg (msg_t *msg_) = 0;
     };
 
 }

--- a/zeromq/src/i_msg_source.hpp
+++ b/zeromq/src/i_msg_source.hpp
@@ -29,14 +29,15 @@ namespace zmq
 
     //  Interface to be implemented by message source.
 
-    struct i_msg_source
+    class i_msg_source
     {
-        virtual ~i_msg_source () {}
+        public:
+          virtual ~i_msg_source () {}
 
-        //  Fetch a message. Returns 0 if successful; -1 otherwise.
-        //  The caller is responsible for freeing the message when no
-        //  longer used.
-        virtual int pull_msg (msg_t *msg_) = 0;
+          //  Fetch a message. Returns 0 if successful; -1 otherwise.
+          //  The caller is responsible for freeing the message when no
+          //  longer used.
+          virtual int pull_msg (msg_t *msg_) = 0;
     };
 
 }

--- a/zeromq/src/socket_base.cpp
+++ b/zeromq/src/socket_base.cpp
@@ -1169,3 +1169,4 @@ void zmq::socket_base_t::stop_monitor()
         monitor_events = 0;
     }
 }
+


### PR DESCRIPTION
Hi Roberto,
These fixes allow zeromq 3.2 to compile without errors under clang 3.8. There are still a couple of warnings in the rest of the project:

src/zeromq/ServerSocket.cpp:37:60: warning: comparison of constant -1 with expression of type 'bool' is always false [-Wtautological-constant-out-of-range-compare]
    if(m_socket->send(address, ZMQ_SNDMORE | ZMQ_DONTWAIT) == -1)
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~
src/zeromq/ServerSocket.cpp:40:67: warning: comparison of constant -1 with expression of type 'bool' is always false [-Wtautological-constant-out-of-range-compare]
    if(m_socket->send(*m_lastAddress, ZMQ_SNDMORE | ZMQ_DONTWAIT) == -1)
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~


Cheers,
Stewart
