### PR TITLE
passing LDFLAGS variable to zeromq build. swapping const/static to av…

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,7 +23,7 @@ $(TAGS):
 	ctags -R ./
 
 $(LIBZMQ):
-	+cd zeromq && CXX=${CXX} CC=${CC} ./configure --with-pic && make
+	+cd zeromq && CXX=${CXX} CC=${CC} LDFLAGS=${LDFLAGS} ./configure --with-pic && make
 
 -include $(DEPS)
 

--- a/zeromq/src/stream_engine.hpp
+++ b/zeromq/src/stream_engine.hpp
@@ -94,7 +94,7 @@ namespace zmq
 
         //  Size of the greeting message:
         //  Preamble (10 bytes) + version (1 byte) + socket type (1 byte).
-        const static size_t greeting_size = 12;
+        static const size_t greeting_size = 12;
 
         handle_t handle;
 


### PR DESCRIPTION
…oid error in gcc

I'm building on NERSC's Cori System. I see this error:

Makefile:729: recipe for target 'libzmq_la-ipc_connecter.lo' failed
make[3]: *** [libzmq_la-ipc_connecter.lo] Error 1
make[3]: *** Waiting for unfinished jobs....
In file included from ipc_listener.cpp(29):
stream_engine.hpp(97): error #82: storage class is not first
          const static size_t greeting_size = 12;

If you swap the static and const, that fixes the error.

Also, I get this error:  
make[2]: Entering directory '/global/project/projectdirs/m2015/panda_cori/yampl/zeromq/perf'
  CXX    local_lat.o
  CXXLD  local_lat
/usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: attempted static link of dynamic object `../src/.libs/libzmq.so'
Makefile:314: recipe for target 'local_lat' failed

I have configured Yampl with LDFLAGS=-dynamic which is required for shared libraries, however you don't pass this flag to the zeromq configure so I added that.

