### PR TITLE
removed change that caused failure to configure

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,7 +23,7 @@ $(TAGS):
 	ctags -R ./
 
 $(LIBZMQ):
-	+cd zeromq && CXX=${CXX} CC=${CC} LDFLAGS=${LDFLAGS} ./configure --with-pic && make
+	+cd zeromq && CXX=${CXX} CC=${CC} ./configure --with-pic && make
 
 -include $(DEPS)
 


### PR DESCRIPTION
I previously added this because I was trying to make it compilable on a supercomputer, but this didn't work as planned. First of all, you need quotations around the ${LDFLAGS} incase the person sets multiple arguments, but since your Makefile already creates an "LDFLAGS" it overwrites whatever the user sets on the command line. In addition, other changes were needed so I'm just removing it. If I find another easy solution I'll upload it.