### PR TITLE
Add examples and tests to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 # @Project YAMPL (Yet Another Message Passing Library)
+#
+# @Options:
+# - WITH_EXAMPLES: Includes examples in the build process
+# - WITH_TESTS: Includes tests in the build process
+#
 message("
      ▄         ▄  ▄▄▄▄▄▄▄▄▄▄▄  ▄▄       ▄▄  ▄▄▄▄▄▄▄▄▄▄▄  ▄
     ▐░▌       ▐░▌▐░░░░░░░░░░░▌▐░░▌     ▐░░▌▐░░░░░░░░░░░▌▐░▌
@@ -76,6 +81,105 @@ add_dependencies(yampl CppZMQ)
 target_include_directories(yampl PRIVATE ${ZEROMQ_INCLUDE_DIR} ${CPPZMQ_INCLUDE_DIR})
 target_link_libraries(yampl ${ZEROMQ_SLIB_DIR}/libzmq.a rt)
 
+# Common libraries (for examples and tests)
+set(YAMPL_COMMON_LIBS ${LIBRARY_OUTPUT_DIRECTORY}/libyampl.so dl uuid ${CMAKE_THREAD_LIBS_INIT})
+
+option(WITH_EXAMPLES "Include examples" ON)
+
+if(WITH_EXAMPLES)
+    # Client-Server
+    add_executable(client examples/client_server/client.cpp)
+    add_executable(server examples/client_server/server.cpp)
+    set_target_properties(client server
+            PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/client_server"
+    )
+    target_link_libraries(client ${YAMPL_COMMON_LIBS})
+    target_link_libraries(server ${YAMPL_COMMON_LIBS})
+    add_dependencies(client yampl)
+    add_dependencies(server yampl)
+
+    # Benchmarks
+    add_executable(benchmark examples/benchmarks/benchmark.cpp)
+    set_target_properties(benchmark
+            PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/benchmark"
+    )
+    target_link_libraries(benchmark ${YAMPL_COMMON_LIBS})
+    add_dependencies(benchmark yampl)
+
+    # Add a custom command to run examples
+    set(YAMPL_EXAMPLE_BENCHMARK $<TARGET_FILE:benchmark>)
+
+    set(YAMPL_EXAMPLE_BENCHMARK0 "${YAMPL_EXAMPLE_BENCHMARK}")
+    set(YAMPL_EXAMPLE_BENCHMARK1 "${YAMPL_EXAMPLE_BENCHMARK} -y")
+    set(YAMPL_EXAMPLE_BENCHMARK2 "${YAMPL_EXAMPLE_BENCHMARK} -y -m 32 -n 128 -s 250000")
+    set(YAMPL_EXAMPLE_BENCHMARK3 "${YAMPL_EXAMPLE_BENCHMARK} -i pipe")
+    set(YAMPL_EXAMPLE_BENCHMARK4 "${YAMPL_EXAMPLE_BENCHMARK} -i pipe -y")
+    set(YAMPL_EXAMPLE_BENCHMARK5 "${YAMPL_EXAMPLE_BENCHMARK} -i pipe -m 32 -n 128 -s 250000")
+    set(YAMPL_EXAMPLE_BENCHMARK6 "${YAMPL_EXAMPLE_BENCHMARK} -i shm")
+    set(YAMPL_EXAMPLE_BENCHMARK7 "${YAMPL_EXAMPLE_BENCHMARK} -i shm -y")
+    set(YAMPL_EXAMPLE_BENCHMARK8 "${YAMPL_EXAMPLE_BENCHMARK} -i shm -m 32 -n 128 -s 250000")
+    set(YAMPL_EXAMPLE_BENCHMARK9 "${YAMPL_EXAMPLE_BENCHMARK} -c THREAD")
+    set(YAMPL_EXAMPLE_BENCHMARK10 "${YAMPL_EXAMPLE_BENCHMARK} -c DISTRIBUTED")
+
+    add_custom_target(example
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK0}'\\; ${YAMPL_EXAMPLE_BENCHMARK0}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK1}'\\; ${YAMPL_EXAMPLE_BENCHMARK1}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK2}'\\; ${YAMPL_EXAMPLE_BENCHMARK2}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK3}'\\; ${YAMPL_EXAMPLE_BENCHMARK3}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK4}'\\; ${YAMPL_EXAMPLE_BENCHMARK4}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK5}'\\; ${YAMPL_EXAMPLE_BENCHMARK5}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK6}'\\; ${YAMPL_EXAMPLE_BENCHMARK6}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK7}'\\; ${YAMPL_EXAMPLE_BENCHMARK7}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK8}'\\; ${YAMPL_EXAMPLE_BENCHMARK8}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK9}'\\; ${YAMPL_EXAMPLE_BENCHMARK9}\\; echo"
+        COMMAND sh -c "echo '${YAMPL_EXAMPLE_BENCHMARK10}'\\; ${YAMPL_EXAMPLE_BENCHMARK10}\\; echo"
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/examples
+    )
+endif()
+
+option(WITH_TESTS "Include tests" ON)
+
+if (WITH_TESTS)
+    enable_testing()
+endif()
+
+if(WITH_TESTS)
+    # Calls Test
+    add_executable(calls tests/calls.cpp)
+    set_target_properties(calls
+            PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+    )
+    target_link_libraries(calls ${YAMPL_COMMON_LIBS})
+
+    add_dependencies(calls yampl)
+    add_test(NAME calls COMMAND calls)
+
+    # Dest Test
+    add_executable(dest tests/dest.cpp)
+    set_target_properties(dest
+            PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+    )
+    target_link_libraries(dest ${YAMPL_COMMON_LIBS})
+
+    add_dependencies(dest yampl)
+    add_test(NAME dest COMMAND dest)
+
+    # Size Test
+    add_executable(size tests/size.cpp)
+    set_target_properties(size
+            PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+    )
+    target_link_libraries(size ${YAMPL_COMMON_LIBS})
+
+    add_dependencies(size yampl)
+    add_test(NAME size COMMAND size)
+endif()
+
 ## @Section Install step
 set_target_properties(yampl PROPERTIES RESOURCE "${YAMPL_RESOURCES}")
     
@@ -93,6 +197,13 @@ install(TARGETS yampl
 	RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/yampl
 	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/yampl
 	PERMISSIONS OWNER_READ OWNER_WRITE
+)
+
+# Install examples
+install(DIRECTORY ${CMAKE_BINARY_DIR}/examples
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
+        PATTERN "*"
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
 )
 
 # Install public header files

--- a/examples/client_server/server.cpp
+++ b/examples/client_server/server.cpp
@@ -6,16 +6,21 @@
 using namespace std;
 using namespace yampl;
 
-int main(int argc, char *argv[]){
-  char ping[100];
-  Channel channel("service", LOCAL_SHM);
-  ISocketFactory *factory = new SocketFactory();
-  ISocket *socket = factory->createServerSocket(channel);
+int main(int argc, char *argv[])
+{
+    char ping[100];
 
-  while(true){
-    socket->recv(ping);
-    socket->send("pong");
-    cout << ping << endl;
-    sleep(1);
-  }
+    cout << "[+] Server launched!" << endl;
+    Channel channel("service", LOCAL_SHM);
+    ISocketFactory *factory = new SocketFactory();
+    cout << "[+] Creating server socket..." << endl;
+    ISocket *socket = factory->createServerSocket(channel);
+
+    cout << "[+] Socket created!" << endl;
+    while(true){
+        socket->recv(ping);
+        socket->send("pong");
+        cout << ping << endl;
+        sleep(1);
+    }
 }

--- a/tests/calls.cpp
+++ b/tests/calls.cpp
@@ -1,6 +1,7 @@
 #include <unistd.h>
 #include <cassert>
 #include <iostream>
+#include <sys/wait.h>
 
 #include "yampl.h"
 
@@ -13,7 +14,7 @@ void client(){
   ISocketFactory *factory = new SocketFactory();
   ISocket *socket = factory->createClientSocket(channel);
   char buffer[] = "Second";
-  
+
   socket->send("First", 6);
 
   socket->send(buffer);
@@ -29,7 +30,7 @@ void client(){
 void server(){
   ISocketFactory *factory = new SocketFactory();
   ISocket *socket = factory->createServerSocket(channel);
-  
+
   char buffer[100];
   char *buffer2 = new char[100];
   float ret;
@@ -50,12 +51,18 @@ void server(){
   delete factory;
 }
 
-int main(){
+int main()
+{
+  int status = -1;
+
   if(fork() == 0){
     client();
   }else{
     server();
-    wait();
-    cout << "Success" << endl;
+    wait(&status);
+    cout << "[calls] Success" << endl;
+        status = 0;
   }
+
+  return status;
 }

--- a/tests/size.cpp
+++ b/tests/size.cpp
@@ -1,69 +1,81 @@
 #include <unistd.h>
 #include <cassert>
 #include <iostream>
+#include <sys/wait.h>
 
 #include "yampl.h"
-#include "yampl/zeromq/SocketFactory.h"
-#include "yampl/pipe/SocketFactory.h"
-#include "yampl/shm/SocketFactory.h"
 
 using namespace std;
 using namespace yampl;
 
 const char message[] = "Hello World!";
 
-void client(ISocketFactory *factory, const Channel &channel){
-  char *buffer = new char[100];
-  ISocket *socket = factory->createClientSocket(channel);
+void client(ISocketFactory* factory, const Channel &channel)
+{
+    char *buffer = new char[100];
+    ISocket *socket = factory->createClientSocket(channel);
 
-  socket->send(message);
+    socket->send(message);
 
-  try{
-    socket->recv(buffer, 1);
-  }catch(InvalidSizeException){
-    socket->recv(buffer, 100);
-  }
+    try {
+        socket->recv(buffer, 1);
+    } catch (InvalidSizeException) {
+        socket->recv(buffer, 100);
+    }
 
-  assert(strcmp(buffer, message) == 0);
+    assert(strcmp(buffer, message) == 0);
 
-  delete socket;
-  delete factory;
+    delete[] buffer;
+    delete socket;
 }
 
-void server(ISocketFactory *factory, const Channel &channel){
-  char *buffer = new char[100];
-  ISocket *socket = factory->createServerSocket(channel);
+void server(ISocketFactory* factory, const Channel &channel)
+{
+    char* buffer = new char[100];
+    ISocket* socket = factory->createServerSocket(channel);
 
-  try{
-    socket->recv(buffer, 1);
-  }catch(InvalidSizeException){
-    socket->recv(buffer, 100);
-  }
+    try {
+        socket->recv(buffer, 1);
+    } catch (InvalidSizeException) {
+        socket->recv(buffer, 100);
+    }
 
-  assert(strcmp(buffer, message) == 0);
-  socket->send(message);
+    assert(strcmp(buffer, message) == 0);
+    socket->send(message);
 
-  delete socket;
-  delete factory;
+    delete[] buffer;
+    delete socket;
 }
 
-int main(int argc, char *argv[]){
-  if(fork() == 0){
-    ISocketFactory *zmqFactory = new zeromq::SocketFactory();
-    client(zmqFactory, Channel("zmq", LOCAL));
-    ISocketFactory *pipeFactory = new pipe::SocketFactory();
-    client(pipeFactory, Channel("pipe", LOCAL_PIPE));
-    ISocketFactory *shmFactory = new shm::SocketFactory();
-    client(shmFactory, Channel("shm", LOCAL_SHM));
-  }else{
-    ISocketFactory *zmqFactory = new zeromq::SocketFactory();
-    server(zmqFactory, Channel("zmq", LOCAL));
-    ISocketFactory *pipeFactory = new pipe::SocketFactory();
-    server(pipeFactory, Channel("pipe", LOCAL_PIPE));
-    ISocketFactory *shmFactory = new shm::SocketFactory();
-    server(shmFactory, Channel("shm", LOCAL_SHM));
+int main(int argc, char *argv[])
+{
+    int status = -1;
+    ISocketFactory* factory;
 
-    wait();
-    cout << "Success" << endl;
-  }
+    if(fork() == 0)
+    {
+        factory = new SocketFactory();
+
+        client(factory, Channel("zmq", LOCAL));
+        client(factory, Channel("pipe", LOCAL_PIPE));
+        client(factory, Channel("shm", LOCAL_SHM));
+
+        delete factory;
+    }
+    else
+    {
+        factory = new SocketFactory();
+
+        server(factory, Channel("zmq", LOCAL));
+        server(factory, Channel("pipe", LOCAL_PIPE));
+        server(factory, Channel("shm", LOCAL_SHM));
+
+        wait(&status);
+        cout << "[size] Success" << endl;
+        status = 0;
+
+        delete factory;
+    }
+
+    return status;
 }


### PR DESCRIPTION
Applying this patch will introduce examples and tests to the CMake build. In
addition to that, examples and tests source code has been updated to print
more meaningful information as well as to fix some errors during compilation
involving `wait` being undefined (including <sys/wait.h> fixes the issue)