### PR TITLE
Missing #include.

### DIFF
--- a/include/yampl/plugin/PluginArbiter.h
+++ b/include/yampl/plugin/PluginArbiter.h
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <vector>
 #include <stack>
+#include <stdexcept>
 
 namespace yampl
 {


### PR DESCRIPTION
Missing #include <stdexcept>.
Fixes compilation failure observed with gcc14.