### PR TITLE
Mark destructors that can throw exceptions.

### DIFF
--- a/include/yampl/ISocket.h
+++ b/include/yampl/ISocket.h
@@ -15,7 +15,7 @@ namespace yampl
     class ISocket
     {
         public:
-            virtual ~ISocket(){}
+            virtual ~ISocket() noexcept(false) {}
 
             virtual void send();
             virtual void send(void *buffer, size_t size, void *hint = 0);

--- a/include/yampl/generic/ServerSocketBase.h
+++ b/include/yampl/generic/ServerSocketBase.h
@@ -21,7 +21,7 @@ template <typename T>
 class ServerSocketBase: public ISocket{
   public:
     ServerSocketBase(const Channel& channel, Semantics semantics, void (*deallocator)(void *, void *), const std::tr1::function<void(T*)> &accept);
-    virtual ~ServerSocketBase();
+    virtual ~ServerSocketBase() noexcept(false);
 
     virtual void send(SendArgs &args);
     virtual ssize_t recv(RecvArgs &args) = 0;
@@ -59,7 +59,7 @@ inline ServerSocketBase<T>::ServerSocketBase(const Channel& channel, Semantics s
 }
 
 template <typename T>
-inline ServerSocketBase<T>::~ServerSocketBase(){
+inline ServerSocketBase<T>::~ServerSocketBase() noexcept(false) {
   m_listener->cancel();
   m_listener->join();
 }

--- a/include/yampl/utils/Poller.h
+++ b/include/yampl/utils/Poller.h
@@ -10,7 +10,7 @@ namespace yampl{
 class Poller{
   public:
     Poller();
-    ~Poller();
+    ~Poller() noexcept(false);
 
     int poll(int timeout = -1);
     int poll(void **data, int timeout = -1);
@@ -29,7 +29,7 @@ inline Poller::Poller(){
   }
 }
 
-inline Poller::~Poller(){
+inline Poller::~Poller() noexcept(false) {
   if(close(m_poll) == -1){
     throw ErrnoException("Failed to close epoll handle");
   }

--- a/include/yampl/utils/SharedMemory.h
+++ b/include/yampl/utils/SharedMemory.h
@@ -11,7 +11,7 @@ namespace yampl{
 class SharedMemory{
   public:
     SharedMemory(const std::string& name, size_t size);
-    ~SharedMemory();
+   ~SharedMemory() noexcept(false);
   
     void *getMemory();
 
@@ -53,7 +53,7 @@ inline SharedMemory::SharedMemory(const std::string& name, size_t size) : m_name
     ErrnoException("Failed to mlock shared memory");
 }
 
-inline SharedMemory::~SharedMemory(){
+inline SharedMemory::~SharedMemory() noexcept(false) {
   if(flock(m_fd, LOCK_EX | LOCK_NB) == 0){
     // The last peer unlinks the shared memory object
     shm_unlink(m_name.c_str());

--- a/include/yampl/utils/Thread.h
+++ b/include/yampl/utils/Thread.h
@@ -11,7 +11,7 @@ namespace yampl{
 class Thread{
   public:
     Thread(const std::tr1::function<void()> &fun);
-    ~Thread();
+   ~Thread() noexcept(false);
 
     void join();
     void detach();
@@ -47,7 +47,7 @@ inline Thread::Thread(const std::tr1::function<void()> &fun) : m_isDestroyable(f
   }
 }
 
-inline Thread::~Thread(){
+inline Thread::~Thread() noexcept(false) {
   if(!m_isDestroyable)
     throw InvalidOperationException("Thread has to be detached or joined");
 


### PR DESCRIPTION
Destructors are implicitly noexcept unless they are explicitly declared otherwise.  Some destructors here can throw, so mark them with noexcept(false).  Fixes warnings observed with clang16.