### PR TITLE
Add missing override keywords.

### DIFF
--- a/include/yampl/SocketFactory.h
+++ b/include/yampl/SocketFactory.h
@@ -38,8 +38,8 @@ namespace yampl
 
             ~SocketFactory() override;
 
-            virtual ISocket *createClientSocket(Channel channel, Semantics semantics = COPY_DATA, void (*deallocator)(void *, void *) = defaultDeallocator, std::string const& name = DEFAULT_ID);
-            virtual ISocket *createServerSocket(Channel channel, Semantics semantics = COPY_DATA, void (*deallocator)(void *, void *) = defaultDeallocator);
+            virtual ISocket *createClientSocket(Channel channel, Semantics semantics = COPY_DATA, void (*deallocator)(void *, void *) = defaultDeallocator, std::string const& name = DEFAULT_ID) override;
+            virtual ISocket *createServerSocket(Channel channel, Semantics semantics = COPY_DATA, void (*deallocator)(void *, void *) = defaultDeallocator) override;
     };
 
 }


### PR DESCRIPTION
Fixes warnings observed with clang16.