### PR TITLE
Fix warning options for clang.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,10 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-terminate -Wno-return-type -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-type -fPIC")
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-terminate")
+endif()
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 

--- a/plugins/yampl-pipe/yampl-pipe.conf.cmake
+++ b/plugins/yampl-pipe/yampl-pipe.conf.cmake
@@ -14,7 +14,9 @@ if (NOT DEFINED WITH_PLUGIN_PIPE OR WITH_PLUGIN_PIPE)
             LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins/yampl-pipe"
     )
     target_link_libraries(yampl-pipe uuid)
-    target_compile_options(yampl-pipe PRIVATE "-Wno-terminate")
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+      target_compile_options(yampl-pipe PRIVATE "-Wno-terminate")
+    endif()
 
     install(TARGETS yampl-pipe
             LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/plugins


### PR DESCRIPTION
-Wno-terminate is not a valid switch for clang.
Enable it only if we're building with gcc.