### PR TITLE
Fix warning from clang on testing function return.

### DIFF
--- a/plugins/yampl-zmq/src/ServerSocket.cpp
+++ b/plugins/yampl-zmq/src/ServerSocket.cpp
@@ -43,11 +43,11 @@ void ServerSocket::sendMessage(zmq::message_t &message, const std::string *peerI
         zmq::message_t address(peerId->size() + 1);
         memcpy((void*)address.data(), peerId->c_str(), peerId->size() + 1);
 
-        if(m_socket->send(address, ZMQ_SNDMORE | ZMQ_DONTWAIT) == -1)
+        if(static_cast<int>(m_socket->send(address, ZMQ_SNDMORE | ZMQ_DONTWAIT)) == -1)
           throw UnroutableException();
       }
       else {
-        if(m_socket->send(*m_lastAddress, ZMQ_SNDMORE | ZMQ_DONTWAIT) == -1)
+        if(static_cast<int>(m_socket->send(*m_lastAddress, ZMQ_SNDMORE | ZMQ_DONTWAIT)) == -1)
           throw UnroutableException();
       }
     }


### PR DESCRIPTION
m_socket->send() returns a bool, but code in ServerSocket.cpp compares it against -1.  clang16 generates a warning that this comparision is never true.

Apparently this is written this way because the library used to return an int here, but now signals errors by raising an exception. Avoid the warning by casting to an int.