### PR TITLE
Fixed gcc13 warnings

### DIFF
--- a/include/yampl/pipe/ServerSocket.h
+++ b/include/yampl/pipe/ServerSocket.h
@@ -30,7 +30,7 @@ inline void ServerSocket::accept(SimpleServerSocket *socket){
 }
 
 inline ssize_t ServerSocket::recv(RecvArgs &args){
- SimpleServerSocket *peer;
+ SimpleServerSocket *peer{nullptr};
 
  if(!m_peerPoll.poll((void **)&peer, args.timeout)){
     return -1;

--- a/src/shm/ServerSocket.cpp
+++ b/src/shm/ServerSocket.cpp
@@ -53,7 +53,7 @@ ssize_t ServerSocket::recv(RecvArgs &args){
     m_lock.unlock();
 
     return ret;
-  }catch(InvalidSizeException){
+  }catch(InvalidSizeException&){
     //TODO: Perform next receive from same peer
     m_lock.unlock();
 

--- a/src/zeromq/ClientSocket.cpp
+++ b/src/zeromq/ClientSocket.cpp
@@ -42,7 +42,7 @@ void ClientSocket::connect(){
     while(true){
       try{
 	m_socket->connect((m_channel.name).c_str());
-      }catch(zmq::error_t err){
+      }catch(zmq::error_t& err){
 	if(err.num() != ECONNREFUSED){
 	  throw ErrnoException();
 	}


### PR DESCRIPTION
1. Uninitialized local variable
2. Catching polymorphic types by value